### PR TITLE
change(tilecache): allow the InMemoryTileCache to grow if the working set is bigger than its capacity

### DIFF
--- a/mapsforge-core/src/main/java/org/mapsforge/core/util/LRUCache.java
+++ b/mapsforge-core/src/main/java/org/mapsforge/core/util/LRUCache.java
@@ -35,7 +35,7 @@ public class LRUCache<K, V> extends LinkedHashMap<K, V> {
         return (int) (capacity / LOAD_FACTOR) + 2;
     }
 
-    public final int capacity;
+    private int capacity;
 
     /**
      * @param capacity the maximum capacity of this cache.
@@ -44,6 +44,14 @@ public class LRUCache<K, V> extends LinkedHashMap<K, V> {
     public LRUCache(int capacity) {
         super(calculateInitialCapacity(capacity), LOAD_FACTOR, true);
         this.capacity = capacity;
+    }
+
+    public void setCapacity(int capacity) {
+        this.capacity = capacity;
+    }
+
+    public int getCapacity() {
+        return capacity;
     }
 
     @Override

--- a/mapsforge-core/src/test/java/org/mapsforge/core/util/LRUCacheTest.java
+++ b/mapsforge-core/src/test/java/org/mapsforge/core/util/LRUCacheTest.java
@@ -27,7 +27,7 @@ public class LRUCacheTest {
 
     private static LRUCache<String, String> createLRUCache(int capacity) {
         LRUCache<String, String> lruCache = new LRUCache<>(capacity);
-        Assert.assertEquals(capacity, lruCache.capacity);
+        Assert.assertEquals(capacity, lruCache.getCapacity());
 
         return lruCache;
     }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/FileSystemTileCache.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/FileSystemTileCache.java
@@ -274,7 +274,7 @@ public class FileSystemTileCache implements TileCache {
     public int getCapacity() {
         try {
             lock.readLock().lock();
-            return this.lruCache.capacity;
+            return this.lruCache.getCapacity();
         } finally {
             lock.readLock().unlock();
         }

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/FileWorkingSetCache.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/FileWorkingSetCache.java
@@ -31,7 +31,7 @@ class FileWorkingSetCache<T> extends WorkingSetCache<T, File> {
 
     @Override
     protected boolean removeEldestEntry(Map.Entry<T, File> eldest) {
-        if (size() > this.capacity) {
+        if (size() > this.getCapacity()) {
             File file = eldest.getValue();
             if (file != null && file.exists() && !file.delete()) {
                 LOGGER.severe("could not delete file: " + file);

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/InMemoryTileCache.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/cache/InMemoryTileCache.java
@@ -64,7 +64,7 @@ public class InMemoryTileCache implements TileCache {
 
     @Override
     public synchronized int getCapacity() {
-        return this.lruCache.capacity;
+        return this.lruCache.getCapacity();
     }
 
     @Override
@@ -120,6 +120,10 @@ public class InMemoryTileCache implements TileCache {
 
     @Override
     public synchronized void setWorkingSet(Set<Job> jobs) {
+        int newCapacity = Math.max(jobs.size(), this.lruCache.getCapacity());
+        if (this.lruCache.getCapacity() < newCapacity) {
+            this.lruCache.setCapacity(newCapacity);
+        }
         this.lruCache.setWorkingSet(jobs);
     }
 
@@ -144,7 +148,7 @@ class BitmapLRUCache extends WorkingSetCache<Job, TileBitmap> {
 
     @Override
     protected boolean removeEldestEntry(Map.Entry<Job, TileBitmap> eldest) {
-        if (size() > this.capacity) {
+        if (size() > this.getCapacity()) {
             TileBitmap bitmap = eldest.getValue();
             if (bitmap != null) {
                 bitmap.decrementRefCount();

--- a/mapsforge-map/src/main/java/org/mapsforge/map/layer/labels/TileBasedLabelStore.java
+++ b/mapsforge-map/src/main/java/org/mapsforge/map/layer/labels/TileBasedLabelStore.java
@@ -90,7 +90,7 @@ public class TileBasedLabelStore extends WorkingSetCache<Tile, List<MapElementCo
 
     @Override
     protected boolean removeEldestEntry(Map.Entry<Tile, List<MapElementContainer>> eldest) {
-        if (size() > this.capacity) {
+        if (size() > this.getCapacity()) {
             return true;
         }
         return false;


### PR DESCRIPTION
The InMemoryTileCache should always be big enough to hold the current working set of tiles at least.